### PR TITLE
Add GitHub issue templates for review workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-ui-functional-review.yml
+++ b/.github/ISSUE_TEMPLATE/01-ui-functional-review.yml
@@ -1,0 +1,98 @@
+name: UI / Functional Review Issue
+description: Report a UI, functional, logic, interaction, or regression issue found during review
+title: "[Review] "
+labels: ["bug", "needs-review"]
+body:
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Type
+      options:
+        - UI
+        - Functional
+        - Logic
+        - Interaction
+        - Regression
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: input
+    id: page_feature
+    attributes:
+      label: Page / Feature
+      placeholder: e.g. Create User page
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Clear explanation of the problem
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Enter ...
+        3. Submit ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Screenshot paths, Playwright observations, console or network notes
+    validations:
+      required: false
+
+  - type: textarea
+    id: fix_direction
+    attributes:
+      label: Suggested fix direction
+    validations:
+      required: false
+
+  - type: textarea
+    id: source_of_truth
+    attributes:
+      label: Source of truth
+      value: |
+        Approved UI design:
+        docker_sca_chain_analysis/design_doc/TrustChainAI_UI.html
+
+        Live implementation:
+        https://trustchainai.ai2wj.com/
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-retest-verification.yml
+++ b/.github/ISSUE_TEMPLATE/02-retest-verification.yml
@@ -1,0 +1,55 @@
+name: Retest / Verification
+description: Record reviewer retest result for a previously fixed issue
+title: "[Retest] "
+labels: ["needs-review"]
+body:
+  - type: input
+    id: original_issue
+    attributes:
+      label: Original issue number
+      placeholder: e.g. #123
+    validations:
+      required: true
+
+  - type: dropdown
+    id: result
+    attributes:
+      label: Retest result
+      options:
+        - Passed
+        - Failed
+        - Partially fixed
+    validations:
+      required: true
+
+  - type: textarea
+    id: replay_steps
+    attributes:
+      label: Retest steps
+      description: Exact steps replayed, usually with Playwright
+    validations:
+      required: true
+
+  - type: textarea
+    id: reviewer_comments
+    attributes:
+      label: Reviewer comments
+    validations:
+      required: true
+
+  - type: textarea
+    id: regression_check
+    attributes:
+      label: Regression check
+    validations:
+      required: false
+
+  - type: dropdown
+    id: final_decision
+    attributes:
+      label: Final decision
+      options:
+        - Close issue
+        - Reopen issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security reporting
+    url: https://github.com/llmsc-security/produce_prototype/security
+    about: Report security-sensitive issues through the repository security process, not public issues.


### PR DESCRIPTION
## Summary
- add two GitHub issue forms for review and retest workflows
- disable blank issues and add a security contact link
- establish the review label taxonomy in the repository

## Verification
- confirmed .github/ISSUE_TEMPLATE/01-ui-functional-review.yml exists
- confirmed .github/ISSUE_TEMPLATE/02-retest-verification.yml exists
- confirmed .github/ISSUE_TEMPLATE/config.yml exists
- confirmed review labels exist with gh label list

## Notes
- source-of-truth references point to docker_sca_chain_analysis design artifacts and the live site only; this PR does not modify that repo